### PR TITLE
COBRA-2015-neptune-error-message

### DIFF
--- a/service/neptune.go
+++ b/service/neptune.go
@@ -106,6 +106,13 @@ func ProvisionNeptune(spec structs.Provisionspec, berr binding.Errors, r render.
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == 503 {
+		body, _ := simplejson.NewFromReader(resp.Body)
+		msg, _ := body.Get("error").String()
+		utils.ReportError(errors.New(msg), r)
+		return
+	}
+
 	if resp.StatusCode > 299 || resp.StatusCode < 200 {
 		utils.ReportError(errors.New(resp.Status), r)
 		return


### PR DESCRIPTION
When preprovisioning is in progress, the neptune broker returns a HTTP 503 (Service Unavailable) status code with a message that tells the user to try again in 10 minutes. This has the region API correctly display this message.