### PR TITLE
Fix struct issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -267,6 +267,14 @@
   version = "v2.3.10"
 
 [[projects]]
+  digest = "1:d7258ee0bc1258f9cca20a8cacefee059127fa51b2399ee6bc2320f4428757f8"
+  name = "gopkg.in/guregu/null.v3"
+  packages = ["zero"]
+  pruneopts = "UT"
+  revision = "80515d440932108546bcade467bb7d6968e812e2"
+  version = "v3.4.0"
+
+[[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
@@ -309,6 +317,7 @@
     "github.com/robfig/cron",
     "github.com/smartystreets/goconvey/convey",
     "github.com/stackimpact/stackimpact-go",
+    "gopkg.in/guregu/null.v3/zero",
     "gopkg.in/mgo.v2",
     "gopkg.in/mgo.v2/bson",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,3 +92,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "gopkg.in/guregu/null.v3"
+  version = "3.4.0"

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -1,6 +1,10 @@
 package structs
 
-import "time"
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v3/zero"
+)
 
 type CertificateOrder struct {
 	Id                      string   `json:"id,omitempty"`
@@ -463,9 +467,9 @@ type QoS struct {
 	Name        string       `json:"name"`
 	Resources   ResourceSpec `json:"resources"`
 	Price       int          `json:"price"`
-	Description string       `json:"description"`
+	Description zero.String  `json:"description"`
 	Deprecated  bool         `json:"deprecated"`
-	Type        string       `json:"type"`
+	Type        zero.String  `json:"type"`
 }
 
 type OneOffSpec struct {


### PR DESCRIPTION
This fixes the following error on a fresh db/install of the region API -  

```bash
[martini] Started GET /v1/apps/plans
2019/05/02 09:38:33 sql: Scan error on column index 6, name "type": unsupported Scan, storing driver.Value type <nil> into type *string
```
 